### PR TITLE
fix #181: 无法通过 -host 参数更改监听地址 & 优化 json 解码逻辑

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ tmp
 tank
 tank.exe
 
+# frontend
+html


### PR DESCRIPTION
- 使用 TankApplication.host 作为 web 服务的监听地址
- 使用流式 json 解析，并在解析完成后关闭 body 以防内存泄漏以修复 #181